### PR TITLE
Use kakoune's automatic escaping for expansions

### DIFF
--- a/rc/snippets.kak
+++ b/rc/snippets.kak
@@ -5,15 +5,15 @@ define-command snippets-enable -docstring 'Enable snippets' %{
   hook window InsertChar \n -group snippets %{ evaluate-commands -draft %{
     execute-keys h
     evaluate-commands %sh{
-      eval "set -- $kak_opt_snippets"
+      set -- $kak_opt_snippets
       while test $# -ge 2; do
-        snippet=$1
+        snippet=$(eval echo "$1")
         expansion=$2
         shift 2
         echo "
           try %{
             execute-keys -draft %(${#snippet}H<a-;>H<a-k>\A\Q$snippet\E\z<ret>c<del>)
-            execute-keys -client %val(client) -with-hooks -save-regs '' %($expansion)
+            execute-keys -client %val(client) -with-hooks -save-regs '' $expansion
           }
         "
       done

--- a/rc/snippets.kak
+++ b/rc/snippets.kak
@@ -7,12 +7,13 @@ define-command snippets-enable -docstring 'Enable snippets' %{
     evaluate-commands %sh{
       set -- $kak_opt_snippets
       while test $# -ge 2; do
-        snippet=$(eval echo "$1")
+        snippet=$1
+        snippet_unesc=$(eval "echo $1")
         expansion=$2
         shift 2
         echo "
           try %{
-            execute-keys -draft %(${#snippet}H<a-;>H<a-k>\A\Q$snippet\E\z<ret>c<del>)
+            execute-keys -draft %(${#snippet_unesc}H<a-;>H<a-k>\A\Q)$snippet%(\E\z<ret>c<del>)
             execute-keys -client %val(client) -with-hooks -save-regs '' $expansion
           }
         "


### PR DESCRIPTION
Kakoune already escapes strings when passing environment variables to shell commands, so there is no need to `eval` the expansions. Doing so and re-quoting the value means that whatever characters are used in the quoting (`(` and `)` in the current code) cannot be used in snippet expansions.

This works with all of my (very few) snippets, but there might be some edge cases for which this doesn't work.