### PR TITLE
Save search register when testing for snippets

### DIFF
--- a/rc/snippets.kak
+++ b/rc/snippets.kak
@@ -12,7 +12,7 @@ define-command snippets-enable -docstring 'Enable snippets' %{
         shift 2
         printf '
           try %%{
-            evaluate-commands -draft %%{
+            evaluate-commands -draft -save-regs "/" %%{
               set-register / %%(\\A\\Q%s\\E\\z)
               execute-keys "%dH<a-;>H<a-k><ret>c<del>"
             }


### PR DESCRIPTION
This allows snippet expansions which use the search register and not have it
overwritten by the time control is returned to the user.

This fixes a regression from 91f1e0c where all but the last snippet defined will have the `/` register overwritten. For example, if the following snippets are defined:
```
set-option window snippets \
    def1 'define-command X %{X}<esc><a-/>X<ret><a-n>c' \
    def2 'define-command X %[X]<esc><a-/>X<ret><a-n>c'
```

Triggering the first one (`def1`) will expand correctly, but the search register will be `\A\Qdef2\E\z`, not `X`.